### PR TITLE
Add support for presales tag

### DIFF
--- a/scripts/success-lessonlearned.coffee
+++ b/scripts/success-lessonlearned.coffee
@@ -7,7 +7,7 @@
 
 
 module.exports = (robot) ->
-    robot.hear /.*#((success)|(lessonlearned)|(nowreading)|(nowlistening)).*/i, (msg) ->
+    robot.hear /.*#((success)|(lessonlearned)|(nowreading)|(nowlistening)|(presales)).*/i, (msg) ->
         user = msg.message.user.name
         data =
             type: msg.match[1],


### PR DESCRIPTION
Presales is a technical team tag used to record presales requests
(questions from bizdev team to technical team).